### PR TITLE
Verify entire application hex file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 dist/
 venv/
+.venv/

--- a/booty/comm_thread.py
+++ b/booty/comm_thread.py
@@ -147,7 +147,7 @@ class BootLoaderThread:
             self.prog_length = msg[1] + (msg[2] << 8) + (msg[3] << 16) + (msg[4] << 24)
             logger.info('program length set: {}'.format(self.prog_length))
 
-            self.local_memory_map = [0xffffff] * (0x200 * self.prog_length >> 1)
+            self.local_memory_map = [None] * (0x200 * self.prog_length >> 1)
 
         elif command == READ_MAX_PROG_SIZE:
             self.max_prog_size = msg[1] + (msg[2] << 8)

--- a/booty/hex.py
+++ b/booty/hex.py
@@ -1,9 +1,33 @@
 import intelhex
 
 
+class AddressSegment:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def to_range(self):
+        return range(self.start, self.end, 2)
+
+    def __iter__(self):
+        return iter(self.to_range())
+
+    def __str__(self):
+        return '[{:06X} : {:06x}]'.format(self.start, self.end)
+
+    def __contains__(self, item):
+        return item in self.to_range()
+
+
 class HexParser:
     def __init__(self, filename):
         self.memory_map = intelhex.IntelHex(filename)
+
+    @property
+    def segments(self):
+        # have to divide by 2, since IntelHex uses byte addresses
+        # and we use addresses of int16's
+        return [AddressSegment(start // 2, end // 2) for start, end in self.memory_map.segments()]
 
     def get_opcode(self, address):
         if address % 2 != 0:

--- a/booty/hex.py
+++ b/booty/hex.py
@@ -6,17 +6,8 @@ class AddressSegment:
         self.start = start
         self.end = end
 
-    def to_range(self):
-        return range(self.start, self.end, 2)
-
-    def __iter__(self):
-        return iter(self.to_range())
-
     def __str__(self):
         return '[{:06X} : {:06x}]'.format(self.start, self.end)
-
-    def __contains__(self, item):
-        return item in self.to_range()
 
 
 class HexParser:
@@ -41,6 +32,7 @@ class HexParser:
         value += self.memory_map[addr + 3] << 24
 
         return value
+
 
 if __name__ == '__main__':
     hp = HexParser('C:/_code/libs/blink.X/dist/default/production/blink.X.production.hex')

--- a/booty/hex.py
+++ b/booty/hex.py
@@ -7,7 +7,7 @@ class AddressSegment:
         self.end = end
 
     def __str__(self):
-        return '[{:06X} : {:06x}]'.format(self.start, self.end)
+        return '[{:06X} : {:06X}]'.format(self.start, self.end)
 
 
 class HexParser:

--- a/booty/util.py
+++ b/booty/util.py
@@ -109,6 +109,8 @@ def verify_hex(boot_loader_app, hex_file_path, retries=3, whitelist_addresses=(0
     logger.info('reading flash from device...')
     for segment in hp.segments:
         for addr in range(segment.start, segment.end, boot_loader_app.max_prog_size):
+            if addr >= boot_loader_app.prog_length:
+                continue
             logger.debug('reading address {:06X}'.format(addr))
             boot_loader_app.read_page(addr)
 
@@ -119,6 +121,9 @@ def verify_hex(boot_loader_app, hex_file_path, retries=3, whitelist_addresses=(0
         for addr in range(segment.start, segment.end, 2):
             if addr in whitelist_addresses:
                 logger.debug('address {:06X} is whitelisted, skipping verification.'.format(addr))
+                continue
+            elif addr >= boot_loader_app.prog_length:
+                logger.debug('address {:06X} is beyond the programming upper bound, skipping verification'.format(addr))
                 continue
 
             m = None

--- a/booty/util.py
+++ b/booty/util.py
@@ -103,11 +103,10 @@ def load_hex(boot_loader_app, hex_file_path):
 
 def verify_hex(boot_loader_app, hex_file_path, retries=3, whitelist_addresses=(0x000000,)):
     okay_so_far = True
-    logger.info('reading flash from device...')
 
     hp = HexParser(hex_file_path)
 
-    logger.info('reading device memory....')
+    logger.info('reading flash from device...')
     for segment in hp.segments:
         for addr in range(segment.start, segment.end, boot_loader_app.max_prog_size):
             logger.debug('reading address {:06X}'.format(addr))


### PR DESCRIPTION
Now booty
1. verifies the entire contents of the bootloaded hex, not just the segment from the end of the bootloader to the end of the app memory.
2. complains if the device stops responding in the middle of verification
3. spits out all verification errors instead of stopping at the first mismatch

> INFO:booty.util:reading flash from device...
> INFO:booty.util:verifying....
> INFO:booty.util:verifying segment [000000 : 0000D0]
> INFO:booty.util:verifying segment [000104 : 0001D0]
> INFO:booty.util:verifying segment [000F00 : 000F12]
> ERROR:booty.util:address 000F00: device value "781F8A" does not match hex value "FA0004"
> ERROR:booty.util:address 000F02: device value "0700BF" does not match hex value "780F00"
> ERROR:booty.util:address 000F04: device value "07FCAD" does not match hex value "980711"
> ERROR:booty.util:address 000F06: device value "07FCC4" does not match hex value "FA8000"
> ERROR:booty.util:address 000F08: device value "2CCCD8" does not match hex value "060000"
> ERROR:booty.util:address 000F0A: device value "23F4C9" does not match hex value "FA0000"
> ERROR:booty.util:address 000F0C: device value "2C350A" does not match hex value "074431"
> ERROR:booty.util:address 000F0E: device value "370008" does not match hex value "073302"
> ERROR:booty.util:address 000F10: device value "FE6000" does not match hex value "37FFFE"
> INFO:booty.util:verifying segment [002000 : 002BFE]
> INFO:booty.util:verifying segment [005400 : 009F30]
> INFO:booty.util:verifying segment [02ABFC : 02AC00]
> ERROR:booty.util:aborting verification. Could not read address 02ABFC.
> WARNING:booty:device verification failed